### PR TITLE
Update regex for PyLNP

### DIFF
--- a/dfdl.rb
+++ b/dfdl.rb
@@ -71,7 +71,7 @@ end
 
 class PyLNPPackage < GitHubPackage
   def match_name
-    /OSX/
+    /OSX|macOS/
   end
 
   def releases_url


### PR DESCRIPTION
The latest releases of PyLNP are marked as macOS instead of OSX. Update
the regex to pull them as well.
