### PR TITLE
Removed line that breaks install

### DIFF
--- a/dfdl.rb
+++ b/dfdl.rb
@@ -190,7 +190,7 @@ class Release
   end
 
   def setup_config
-    FileUtils.cp("#{release_dir}/df_osx/dfhack.init-example", "#{release_dir}/df_osx/dfhack.init")
+    #FileUtils.cp("#{release_dir}/df_osx/dfhack.init-example", "#{release_dir}/df_osx/dfhack.init")
     init_file_path = "#{release_dir}/df_osx/data/init/init.txt"
     File.write(init_file_path, File.read(init_file_path).gsub("[PRINT_MODE:2D]", "[PRINT_MODE:TWBT]"))
   end


### PR DESCRIPTION
A line in the main Ruby install file attempts to copy a file in dfhack that no longer exists. I have commented it out.

The offending line is line 193, which attempts to pull the now nonexistent file `#{release_dir}/df_osx/dfhack.init-example` and copy it to the file `#{release_dir}/df_osx/dfhack.init`. As of now, afaik dfhack is packaged with a working dfhack.init and doesn't need the example copied, but I'm not nearly as familiar with the underlying code.

Thanks!